### PR TITLE
Fix hang on unterminated string literal

### DIFF
--- a/recipe/parser.go
+++ b/recipe/parser.go
@@ -566,8 +566,18 @@ func (s *Scanner) scanLiteral() (Token, string) {
 
 	for {
 		ch := s.read()
+		if ch == eof {
+			// Unterminated literal - hitting EOF before the closing quote.
+			// Signal an error rather than looping forever appending eof.
+			return ILLEGAL, buf.String()
+		}
 		if ch == '\\' {
-			_, _ = buf.WriteRune(s.read())
+			escaped := s.read()
+			if escaped == eof {
+				// Trailing backslash with no following character before EOF.
+				return ILLEGAL, buf.String()
+			}
+			_, _ = buf.WriteRune(escaped)
 		} else if ch != '"' {
 			_, _ = buf.WriteRune(ch)
 		} else {

--- a/recipe/parser_test.go
+++ b/recipe/parser_test.go
@@ -557,6 +557,24 @@ func TestParse(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name:    "unterminated literal is an error, not a hang",
+			args:    args{source: strings.NewReader(`1 <- "oops`)},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "unterminated literal after a join is an error, not a hang",
+			args:    args{source: strings.NewReader(`1 <- 2 + "oops`)},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "trailing backslash in literal is an error, not a hang",
+			args:    args{source: strings.NewReader("1 <- \"oops\\")},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
scanLiteral looped forever on a recipe containing an unterminated quote: past end-of-input read() returns rune(0), which is neither a backslash nor a closing quote, so it was appended to the buffer indefinitely, hanging the process and growing memory without bound. A trailing backslash before EOF hit the same path.

Return ILLEGAL on EOF so the parser surfaces a normal parse error, consistent with how malformed assignment and pipe tokens are already handled. Add regression tests covering an unterminated literal, an unterminated literal after a join, and a trailing backslash.

Closes #33