### PR TITLE
Make age() use the injectable clock

### DIFF
--- a/recipe/helper_functions.go
+++ b/recipe/helper_functions.go
@@ -259,7 +259,7 @@ func Age(dob string) (string, error) {
 	}
 	// Ignoring the error because SmartDate would have already failed on a bad date
 	birthdate, _ := time.Parse(time.RFC3339, normalizedDate)
-	now := time.Now()
+	now := Now()
 	years := now.Year() - birthdate.Year()
 	if now.YearDay() < birthdate.YearDay() {
 		years--

--- a/recipe/parse_execute_test.go
+++ b/recipe/parse_execute_test.go
@@ -710,7 +710,10 @@ func TestTransformation_ParseExecute(t *testing.T) {
 			name:   "age function calculates an age based on a provided dob field",
 			recipe: "1 <- age(1)",
 			input:  "1977-11-07\n2004-02-03\n",
-			want:   "44\n18\n",
+			// Now is pinned to 2021-08-30 (see the Now override below): the
+			// 1977-11-07 birthday has not yet occurred in 2021 (age 43), while
+			// 2004-02-03 already has (age 17).
+			want: "43\n17\n",
 		},
 	}
 


### PR DESCRIPTION
Age() called time.Now() directly while every other date-aware function uses the package-level Now var. The test pinned Now to 2021-08-30 but Age ignored it, so the result drifted with the real clock and the suite failed every year (most recently 48/22 instead of the fixture values).

Use Now() so the result is deterministic and testable. The expected ages are corrected to 43 and 17, which are the true completed-year ages for the fixture as of the pinned 2021-08-30 date; the previous 44/18 only matched a ~2022 wall clock and was never correct for the fixture.

Closes #34