### PR TITLE
Guard against nil close on file-open failure

### DIFF
--- a/cmd/read.go
+++ b/cmd/read.go
@@ -47,12 +47,11 @@ var readCmd = &cobra.Command{
 
 func runRead(cmd *cobra.Command, args []string) {
 	csvFile, closeFunc, err := csv.NewCsvSource(args[0])
-	defer closeFunc()
-
 	if err != nil {
 		log.Errorf("%+v", err)
 		os.Exit(1)
 	}
+	defer closeFunc()
 
 	for {
 		line, err := csvFile.Read()

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/martian/log"
 	"github.com/spf13/cobra"
 	"math/rand"
+	"os"
 	"syreclabs.com/go/faker"
 	"time"
 )
@@ -49,11 +50,11 @@ var lines int
 
 func runWrite(cmd *cobra.Command, args []string) {
 	output, closeFunc, err := csv.NewOutputSource(args[0])
-	defer closeFunc()
-
 	if err != nil {
 		log.Errorf("%+v", err)
+		os.Exit(1)
 	}
+	defer closeFunc()
 
 	output.Write([]string{
 		"voter_id",


### PR DESCRIPTION
## What

`read` and `write` registered `defer closeFunc()` *before* checking the
error from opening the file. `csv.NewCsvSource` / `csv.NewOutputSource`
return a `nil` `closeFunc` on error, so the deferred nil call panicked
instead of reporting the failure. `write` additionally continued past
the error and used the nil writer.

## Fix

- Check the error and `os.Exit(1)` **before** deferring the close.
- `write` now exits non-zero on failure (added the `os` import) instead
  of falling through.

## Verification

```
$ csv-chef read /nonexistent/path.csv
ERROR: open /nonexistent/path.csv: no such file or directory   # exit 1, no panic

$ csv-chef write /nonexistent/dir/out.csv
ERROR: open /nonexistent/dir/out.csv: no such file or directory # exit 1, no panic
```

`go build ./...` clean; `go test ./...` green.

Closes #37