### PR TITLE
Add CI workflow for build, vet, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      - name: Verify gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race -timeout 120s ./...


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs on pushes to `main` and on PRs targeting `main`:

- `gofmt` verification (fails on unformatted files)
- `go vet ./...`
- `go build ./...`
- `go test -race -timeout 120s ./...`

Once this is on `main`, the `build-and-test` check can be made a required status check on the branch protection rule, so merges gate on a green build.