### PR TITLE
Fix wrong variable in bake output-exists error

### DIFF
--- a/cmd/bake.go
+++ b/cmd/bake.go
@@ -81,7 +81,7 @@ func runBake(cmd *cobra.Command, args []string) {
 
 	// ensure output doesn't exist, or force is specified
 	if _, err := os.Stat(outputFile); err == nil && !forceOverwrite {
-		log.Errorf("Output file already exists: %s", output)
+		log.Errorf("Output file already exists: %s", outputFile)
 		os.Exit(5)
 	}
 


### PR DESCRIPTION
The bake command's "Output file already exists" error logged the `output` variable, which belongs to the identity command's global flag and is empty during a bake run. The message therefore never showed the offending path. Switched to `outputFile`, the bake command's own flag variable.

Closes #36