### PR TITLE
Handle non-EOF errors in read command

### DIFF
--- a/cmd/read.go
+++ b/cmd/read.go
@@ -58,6 +58,10 @@ func runRead(cmd *cobra.Command, args []string) {
 		if err == io.EOF {
 			break
 		}
+		if err != nil {
+			log.Errorf("Error reading CSV: %v", err)
+			os.Exit(1)
+		}
 		fmt.Println(line)
 	}
 }


### PR DESCRIPTION
The read loop only broke on io.EOF and printed the returned line unconditionally, so any other read error printed a nil row and exited zero, masking the failure.

This reports the error via `log.Errorf` and exits non-zero (consistent with the rest of the command), and skips printing the line on error.

Closes #38