### PR TITLE
Add opt-in CSV formula-injection sanitizer to bake

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The program requires an input CSV file, an output CSV file, and a recipe file. C
 
 If the bake function runs into a parse error when processing the incoming CSV file (think wrong number of fields) the default functionality will be to output the bad line to standard out, skip writing the line to the output file, and to continue processing the remaining lines. If you'd prefer that processing stops, you can provide the `-p` or `--parseErrorIsError` flag. With this flag provided, the first time a CSV parsing error happens, it will still output the offending line, but it will stop processing and exit with an error code.
 
+To guard against spreadsheet formula injection, you can provide the `-s` or `--sanitize` flag. When enabled, any output cell that begins with a character a spreadsheet might interpret as a formula (`=`, `+`, `-`, `@`, a tab, or a carriage return) is prefixed with a single quote. This is opt-in; by default output cells are written unchanged.
+
 Please see the recipes section for information about how to build recipes for the program.
 
 Write

--- a/cmd/bake.go
+++ b/cmd/bake.go
@@ -38,6 +38,7 @@ var (
 	inputFile      string
 	outputFile     string
 	recipeFile     string
+	sanitize       bool
 )
 
 // bakeCmd represents the bake command
@@ -105,6 +106,8 @@ func runBake(cmd *cobra.Command, args []string) {
 		os.Exit(7)
 	}
 
+	transformer.Sanitize = sanitize
+
 	// Don't count the header
 	if transformLines > 0 && !disableHeader {
 		transformLines++
@@ -135,6 +138,7 @@ func init() {
 	bakeCmd.Flags().StringVarP(&outputFile, "out", "o", "", "-o /path/to/output.csv")
 	bakeCmd.Flags().StringVarP(&recipeFile, "recipe", "r", "", "-r /path/to/recipe.txt")
 	bakeCmd.Flags().BoolP("parseErrorIsError", "p", false, "-p")
+	bakeCmd.Flags().BoolVarP(&sanitize, "sanitize", "s", false, "--sanitize (prefix risky cells with a quote to prevent spreadsheet formula injection)")
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// bakeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")

--- a/recipe/helper_functions.go
+++ b/recipe/helper_functions.go
@@ -341,3 +341,17 @@ func MassProcess(incoming []string, processor Processor) (out []string) {
 	}
 	return
 }
+
+// SanitizeField guards against CSV formula injection by prefixing a
+// single quote to any value that begins with a character a spreadsheet
+// may interpret as a formula.
+func SanitizeField(s string) string {
+	if s == "" {
+		return s
+	}
+	switch s[0] {
+	case '=', '+', '-', '@', '\t', '\r':
+		return "'" + s
+	}
+	return s
+}

--- a/recipe/helper_functions_test.go
+++ b/recipe/helper_functions_test.go
@@ -133,3 +133,28 @@ func TestNoDigits(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeField(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"leading equals", "=1+1", "'=1+1"},
+		{"leading plus", "+1", "'+1"},
+		{"leading minus", "-1", "'-1"},
+		{"leading at", "@SUM(A1)", "'@SUM(A1)"},
+		{"leading tab", "\tvalue", "'\tvalue"},
+		{"leading carriage return", "\rvalue", "'\rvalue"},
+		{"normal text", "hello", "hello"},
+		{"empty string", "", ""},
+		{"equals not at start", "a=b", "a=b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SanitizeField(tt.input); got != tt.want {
+				t.Errorf("SanitizeField(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/recipe/recipe.go
+++ b/recipe/recipe.go
@@ -82,6 +82,7 @@ type Transformation struct {
 	Columns       map[int]Recipe
 	Headers       map[int]Recipe
 	VariableOrder []string
+	Sanitize      bool
 }
 
 type TransformationResult struct {
@@ -287,7 +288,11 @@ func (t *Transformation) Execute(reader *csv.Reader, writer *csv.Writer, process
 func (t *Transformation) outputCsvRow(numColumns int, output map[int]string, writer *csv.Writer) error {
 	var outputRow []string
 	for i := 1; i <= numColumns; i++ {
-		outputRow = append(outputRow, output[i])
+		cell := output[i]
+		if t.Sanitize {
+			cell = SanitizeField(cell)
+		}
+		outputRow = append(outputRow, cell)
 	}
 	err := writer.Write(outputRow)
 	if err != nil {


### PR DESCRIPTION
Adds an opt-in `-s`/`--sanitize` flag to the `bake` command to guard against CSV formula injection.

When enabled, any output cell whose first character is one a spreadsheet may interpret as a formula (`=`, `+`, `-`, `@`, tab `0x09`, or carriage return `0x0D`) is prefixed with a single quote, neutralizing the formula while keeping the visible value intact.

The behavior is gated by a new `Transformation.Sanitize` field that defaults to `false`. The `Execute` signature is unchanged. Default output is identical to before this change, so it is fully backward compatible; sanitizing happens only when the flag is passed.

Includes unit tests for `SanitizeField` (each risky leading char, plus safe inputs: normal text, empty string, and `a=b`) and a README note. `gofmt`, `go vet`, `go build`, and `go test ./...` all pass.

Closes #39