### PR TITLE
Restrict CI workflow token to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege: CI only needs to read the repo to check out, build, and
+# test. This caps what the GITHUB_TOKEN can do, including on pull requests.
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: build-and-test


### PR DESCRIPTION
Adds an explicit least-privilege `permissions: contents: read` block to the CI workflow. CI only needs to read the repo to check out, build, and test, so this caps what the `GITHUB_TOKEN` can do — limiting the blast radius if untrusted code runs on a pull request.

Paired with setting the repository's **default workflow token permissions to read-only** (Settings → Actions → General → Workflow permissions), which has already been applied via the API.

No impact on the day-to-day workflow; purely a token-scope reduction.