### PR TITLE
Add golangci-lint with a standard-config gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,6 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,21 @@ jobs:
 
       - name: Test
         run: go test -race -timeout 120s ./...
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.12.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+# Use golangci-lint's standard linter set: errcheck, govet, ineffassign,
+# staticcheck, and unused. These catch real correctness issues (unchecked
+# errors, ineffectual assignments, suspicious constructs) without a lot of
+# stylistic noise.
+linters:
+  default: standard

--- a/cmd/bake.go
+++ b/cmd/bake.go
@@ -78,7 +78,7 @@ func runBake(cmd *cobra.Command, args []string) {
 		log.Errorf("Error opening input file: %v", err)
 		os.Exit(1)
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }()
 
 	// ensure output doesn't exist, or force is specified
 	if _, err := os.Stat(outputFile); err == nil && !forceOverwrite {
@@ -91,14 +91,14 @@ func runBake(cmd *cobra.Command, args []string) {
 		log.Errorf("Error creating output file: %v", err)
 		os.Exit(6)
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
 	recipeFile, err := os.Open(recipeFile)
 	if err != nil {
 		log.Errorf("Unable to open recipe file: %v", err)
 		os.Exit(6)
 	}
-	defer recipeFile.Close()
+	defer func() { _ = recipeFile.Close() }()
 
 	transformer, err := recipe.Parse(recipeFile)
 	if err != nil {

--- a/cmd/identity.go
+++ b/cmd/identity.go
@@ -89,7 +89,7 @@ func runIdentity(cmd *cobra.Command, args []string) {
 			log.Errorf("Unable to open output file: %v", err)
 			os.Exit(1)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		w = f
 	} else {
 		w = os.Stdout
@@ -98,9 +98,11 @@ func runIdentity(cmd *cobra.Command, args []string) {
 	for zeroIndex, column := range row {
 		num := zeroIndex + 1
 		if withHeaders {
-			_, err = fmt.Fprintf(w, "!%d <- %d # %s header\n", num, num, trimBom(column))
-			_, err = fmt.Fprintf(w, "%d <- %d # %s\n", num, num, trimBom(column))
-			if err != nil {
+			if _, err = fmt.Fprintf(w, "!%d <- %d # %s header\n", num, num, trimBom(column)); err != nil {
+				log.Errorf("Error writing header recipe: %v", err)
+				os.Exit(10)
+			}
+			if _, err = fmt.Fprintf(w, "%d <- %d # %s\n", num, num, trimBom(column)); err != nil {
 				log.Errorf("Error writing header recipe: %v", err)
 				os.Exit(10)
 			}

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -51,7 +51,7 @@ func runRead(cmd *cobra.Command, args []string) {
 		log.Errorf("%+v", err)
 		os.Exit(1)
 	}
-	defer closeFunc()
+	defer func() { _ = closeFunc() }()
 
 	for {
 		line, err := csvFile.Read()

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -54,9 +54,9 @@ func runWrite(cmd *cobra.Command, args []string) {
 		log.Errorf("%+v", err)
 		os.Exit(1)
 	}
-	defer closeFunc()
+	defer func() { _ = closeFunc() }()
 
-	output.Write([]string{
+	_ = output.Write([]string{
 		"voter_id",
 		"first",
 		"last",
@@ -76,7 +76,7 @@ func runWrite(cmd *cobra.Command, args []string) {
 			sent = faker.Date().Between(time.Now().AddDate(0, 0, -10), time.Now().AddDate(0, 0, 10)).Format("2006-01-02")
 		}
 
-		output.Write([]string{
+		_ = output.Write([]string{
 			faker.Number().Between(100000, 99999999),
 			faker.Name().FirstName(),
 			faker.Name().LastName(),

--- a/recipe/execute_test.go
+++ b/recipe/execute_test.go
@@ -18,6 +18,6 @@ func BenchmarkExecute(b *testing.B) {
 	buf.Reset()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		transformation.Execute(reader, writer, true, -1, false)
+		_, _ = transformation.Execute(reader, writer, true, -1, false)
 	}
 }

--- a/recipe/helper_functions.go
+++ b/recipe/helper_functions.go
@@ -155,7 +155,7 @@ func Repeat(count string, input string) (string, error) {
 }
 
 func ReplaceString(search string, replace string, input string) (string, error) {
-	return strings.Replace(input, search, replace, -1), nil
+	return strings.ReplaceAll(input, search, replace), nil
 }
 
 func Today(now func() time.Time) (string, error) {
@@ -219,6 +219,9 @@ func IsPast(past string, future string, date string) (string, error) {
 		return "", fmt.Errorf("unable to recognize date: %v", err)
 	}
 	actualDate, err := time.Parse(time.RFC3339, normalizedDate)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse date: %v", err)
+	}
 	now := Now()
 	if now.After(actualDate) {
 		return past, nil
@@ -232,6 +235,9 @@ func IsFuture(future string, past string, date string) (string, error) {
 		return "", fmt.Errorf("unable to recognize date: %v", err)
 	}
 	actualDate, err := time.Parse(time.RFC3339, normalizedDate)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse date: %v", err)
+	}
 	now := Now()
 	if now.Before(actualDate) {
 		return future, nil
@@ -322,7 +328,7 @@ func Change(from string, to string, input string) (string, error) {
 }
 
 func ChangeI(from string, to string, input string) (string, error) {
-	if strings.ToLower(input) == strings.ToLower(from) {
+	if strings.EqualFold(input, from) {
 		return to, nil
 	}
 	return input, nil

--- a/recipe/parser.go
+++ b/recipe/parser.go
@@ -81,20 +81,21 @@ func Parse(source io.Reader) (*Transformation, error) {
 		// Found column or variable to assign result to
 		target := lit
 		var targetType DataType
-		if tok == COLUMN_ID {
+		switch tok {
+		case COLUMN_ID:
 			err := transformation.AddOutputToColumn(lit)
 			if err != nil {
 				return nil, fmt.Errorf("error - line %d: %s", lineNo+1, err.Error())
 			}
 			targetType = Column
-		} else if tok == VARIABLE {
+		case VARIABLE:
 			err := transformation.AddOutputToVariable(lit)
 			if err != nil {
 				return nil, fmt.Errorf("error - line %d: %s", lineNo+1, err.Error())
 			}
 			transformation.VariableOrder = append(transformation.VariableOrder, lit)
 			targetType = Variable
-		} else if tok == HEADER {
+		case HEADER:
 			err := transformation.AddOutputToHeader(lit)
 			if err != nil {
 				return nil, fmt.Errorf("error - line %d: %s", lineNo+1, err.Error())
@@ -124,7 +125,7 @@ func Parse(source io.Reader) (*Transformation, error) {
 			}
 			transformation.AddOperationByType(targetType, target, operation)
 		default:
-			return nil, fmt.Errorf("unexpected token [%d] %s\n", tok, lit)
+			return nil, fmt.Errorf("unexpected token [%d] %s", tok, lit)
 		}
 
 	LOOPSCAN:
@@ -134,7 +135,7 @@ func Parse(source io.Reader) (*Transformation, error) {
 			case EOF:
 				break LOOPSCAN
 			case PIPE:
-				break
+				// a pipe just connects to the next operand scanned below
 			case PLUS:
 				transformation.AddOperationByType(targetType, target, getJoinWithPlaceholder())
 			case COMMENT:
@@ -157,7 +158,7 @@ func Parse(source io.Reader) (*Transformation, error) {
 				}
 				break LOOPSCAN
 			default:
-				break
+				// any other connector token falls through to scan the next operand
 			}
 
 			// After connection scan stuff we can do (column, variable, literal, function)
@@ -265,7 +266,7 @@ func getOutputForHeader(h string) Output {
 func consumeAssignment(p *Parser) error {
 	tok, lit := p.scanIgnoreWhitespace()
 	if tok != ASSIGNMENT {
-		return fmt.Errorf("expected assignment ( <- ) but found [%s] (%d) instead.\n", lit, tok)
+		return fmt.Errorf("expected assignment ( <- ) but found [%s] (%d) instead", lit, tok)
 	}
 	return nil
 }
@@ -318,7 +319,7 @@ ARGLOOP:
 		case VARIABLE:
 			args = append(args, variableArg(lit))
 		case COMMA:
-			break
+			// commas just separate arguments; keep scanning
 		case CLOSE_PAREN:
 			break ARGLOOP
 		default:

--- a/recipe/recipe.go
+++ b/recipe/recipe.go
@@ -179,10 +179,7 @@ func (t *Transformation) Execute(reader *csv.Reader, writer *csv.Writer, process
 	}
 	var linesRead int
 
-	for {
-		if lineLimit > 0 && linesRead >= lineLimit {
-			break
-		}
+	for lineLimit <= 0 || linesRead < lineLimit {
 		row, err := reader.Read()
 		if err == io.EOF {
 			break
@@ -623,7 +620,8 @@ func getPlaceholderArg() Argument {
 func (t *Transformation) AddOperationToVariable(variable string, operation Operation) {
 	recipe, ok := t.Variables[variable]
 	if !ok {
-		t.AddOutputToVariable(variable)
+		// safe to ignore: the error only occurs if already defined, but !ok
+		_ = t.AddOutputToVariable(variable)
 		recipe = t.Variables[variable]
 	}
 	pipe := recipe.Pipe
@@ -639,7 +637,8 @@ func (t *Transformation) AddOperationToColumn(column string, operation Operation
 	columnNumber, _ := strconv.Atoi(column)
 	recipe, ok := t.Columns[columnNumber]
 	if !ok {
-		t.AddOutputToColumn(column)
+		// safe to ignore: the error only occurs if already defined, but !ok
+		_ = t.AddOutputToColumn(column)
 		recipe = t.Columns[columnNumber]
 	}
 	pipe := recipe.Pipe
@@ -655,7 +654,8 @@ func (t *Transformation) AddOperationToHeader(header string, operation Operation
 	headerNumber, _ := strconv.Atoi(header)
 	recipe, ok := t.Headers[headerNumber]
 	if !ok {
-		t.AddOutputToHeader(header)
+		// safe to ignore: the error only occurs if already defined, but !ok
+		_ = t.AddOutputToHeader(header)
 		recipe = t.Headers[headerNumber]
 	}
 	pipe := recipe.Pipe

--- a/recipe/recipe_test.go
+++ b/recipe/recipe_test.go
@@ -143,7 +143,7 @@ func TestTransformation_AddOutputToVariable(t1 *testing.T) {
 	for _, tt := range tests {
 		t1.Run(tt.name, func(t1 *testing.T) {
 			t := NewTransformation()
-			t.AddOutputToVariable(tt.variable)
+			_ = t.AddOutputToVariable(tt.variable)
 			got := t.Variables[tt.variable].Output
 			if got != tt.want {
 				t1.Errorf("Dump() = %v, want %v", got, tt.want)
@@ -172,7 +172,7 @@ func TestTransformation_AddOutputToHeader(t1 *testing.T) {
 	for _, tt := range tests {
 		t1.Run(tt.name, func(t1 *testing.T) {
 			t := NewTransformation()
-			t.AddOutputToHeader(tt.header)
+			_ = t.AddOutputToHeader(tt.header)
 			got := t.Headers[tt.headerNum].Output
 			if got != tt.want {
 				t1.Errorf("Dump() = %v, want %v", got, tt.want)
@@ -201,7 +201,7 @@ func TestTransformation_AddOutputToColumn(t1 *testing.T) {
 	for _, tt := range tests {
 		t1.Run(tt.name, func(t1 *testing.T) {
 			t := NewTransformation()
-			t.AddOutputToColumn(tt.column)
+			_ = t.AddOutputToColumn(tt.column)
 
 			got := t.Columns[tt.columnNum].Output
 			if got != tt.want {


### PR DESCRIPTION
Adopts golangci-lint and wires it into CI as a separate `lint` job so merges gate on a clean lint.

## Added
- `.golangci.yml` — golangci-lint v2 config using the **standard** linter set (errcheck, govet, ineffassign, staticcheck, unused).
- A `lint` job in `.github/workflows/ci.yml` (pinned to golangci-lint `v2.12.1`).

## Fixed (the 27 issues it flagged on existing code)
- **Two real latent bugs:** `IsPast` / `IsFuture` captured `err` from `time.Parse` and never checked it — a parse failure was silently ignored. Now returns the error.
- **errcheck:** unchecked `Close`/`Write`/`AddOutput*` returns made explicit (deferred closes wrapped, intentional ignores marked `_ =`).
- **ineffassign:** fixed the overwritten `err` in `identity.go`'s header writes.
- **staticcheck:** `strings.ReplaceAll`, `strings.EqualFold`, trailing newlines removed from error strings, `if/else-if` → tagged `switch`, loop guard lifted into the `for` condition, and three redundant `break` no-ops removed from parser `switch` blocks.

No behavior changes other than the two `IsPast`/`IsFuture` error fixes. `gofmt`, `go vet`, `go build`, `go test -race`, and `golangci-lint run` all pass locally.

## Follow-up
Once merged, the `lint` check needs to be added to `main`'s required status checks (the context only exists on `main` after this lands). I can do that via the API after merge.