### PR TITLE
Support stdin/stdout streaming in bake

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The program requires an input CSV file, an output CSV file, and a recipe file. C
 
 If the bake function runs into a parse error when processing the incoming CSV file (think wrong number of fields) the default functionality will be to output the bad line to standard out, skip writing the line to the output file, and to continue processing the remaining lines. If you'd prefer that processing stops, you can provide the `-p` or `--parseErrorIsError` flag. With this flag provided, the first time a CSV parsing error happens, it will still output the offending line, but it will stop processing and exit with an error code.
 
+You can stream data through `csv-chef` instead of using files. Pass `-i -` to read the input CSV from standard input, and pass `-o -` to write the output CSV to standard output. When writing to standard output, the "output file already exists" check is skipped and status messages are sent to standard error so they don't pollute the CSV stream. For example: `printf 'a\nb\n' | csv-chef bake -i - -o - -r recipe.txt -d`.
+
 To guard against spreadsheet formula injection, you can provide the `-s` or `--sanitize` flag. When enabled, any output cell that begins with a character a spreadsheet might interpret as a formula (`=`, `+`, `-`, `@`, a tab, or a carriage return) is prefixed with a single quote. This is opt-in; by default output cells are written unchanged.
 
 Please see the recipes section for information about how to build recipes for the program.

--- a/cmd/bake.go
+++ b/cmd/bake.go
@@ -24,9 +24,11 @@ package cmd
 import (
 	"encoding/csv"
 	"fmt"
+	"io"
+	"os"
+
 	"github.com/dstockto/csv-chef/recipe"
 	"github.com/google/martian/log"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -73,25 +75,37 @@ func runBake(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	in, err := os.Open(inputFile)
-	if err != nil {
-		log.Errorf("Error opening input file: %v", err)
-		os.Exit(1)
+	var in io.Reader
+	if inputFile == "-" {
+		in = os.Stdin
+	} else {
+		inFile, err := os.Open(inputFile)
+		if err != nil {
+			log.Errorf("Error opening input file: %v", err)
+			os.Exit(1)
+		}
+		defer func() { _ = inFile.Close() }()
+		in = inFile
 	}
-	defer func() { _ = in.Close() }()
 
-	// ensure output doesn't exist, or force is specified
-	if _, err := os.Stat(outputFile); err == nil && !forceOverwrite {
-		log.Errorf("Output file already exists: %s", outputFile)
-		os.Exit(5)
-	}
+	var out io.Writer
+	if outputFile == "-" {
+		out = os.Stdout
+	} else {
+		// ensure output doesn't exist, or force is specified
+		if _, err := os.Stat(outputFile); err == nil && !forceOverwrite {
+			log.Errorf("Output file already exists: %s", outputFile)
+			os.Exit(5)
+		}
 
-	out, err := os.Create(outputFile)
-	if err != nil {
-		log.Errorf("Error creating output file: %v", err)
-		os.Exit(6)
+		outFile, err := os.Create(outputFile)
+		if err != nil {
+			log.Errorf("Error creating output file: %v", err)
+			os.Exit(6)
+		}
+		defer func() { _ = outFile.Close() }()
+		out = outFile
 	}
-	defer func() { _ = out.Close() }()
 
 	recipeFile, err := os.Open(recipeFile)
 	if err != nil {
@@ -119,8 +133,8 @@ func runBake(cmd *cobra.Command, args []string) {
 		os.Exit(8)
 	}
 
-	fmt.Printf("Baking complete. Your output is here: %s\n\n", outputFile)
-	fmt.Printf("Processed %d header lines and %d input lines\n", result.HeaderLines, result.Lines)
+	fmt.Fprintf(os.Stderr, "Baking complete. Your output is here: %s\n\n", outputFile)
+	fmt.Fprintf(os.Stderr, "Processed %d header lines and %d input lines\n", result.HeaderLines, result.Lines)
 }
 
 func init() {


### PR DESCRIPTION
Adds streaming support to the `bake` command:

- `-i -` reads the input CSV from standard input.
- `-o -` writes the output CSV to standard output, skips the
  "output file already exists" check, and leaves the stream open.
- Status messages ("Baking complete...", "Processed ... lines") now go
  to standard error so they never pollute the CSV stream.

Default file-path behavior is unchanged: any path other than `-` opens
or creates a file exactly as before.

Closes #51