### PR TITLE
Add lint command for recipe dry-run validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ $ csv-chef identity -w input.csv
 10 <- 10 # sent
 ```
 
+Lint
+==
+
+The `lint` command parses and validates a recipe without transforming any data. It is a quick dry-run that catches problems before you bake. Use `-r` or `--recipe` to specify the recipe file (required). Lint reports parse errors (such as unknown functions, unterminated literals or incorrect argument counts) as well as recipe validation errors (such as missing column definitions).
+
+If you also provide an input CSV with `-i` or `--in`, lint reads the header row and verifies that the recipe does not reference an input column number greater than the number of columns in that header. This catches recipes that would fail against a particular input file.
+
+On success it prints `Recipe OK` and exits 0. On any problem it prints a description of the issue and exits with a non-zero status.
+
+Example:
+
+```
+$ csv-chef lint -r recipe.txt -i input.csv
+Recipe OK
+```
+
 Recipes
 ==
 

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,0 +1,115 @@
+/*
+Copyright © 2021 David Stockton <dave@davidstockton.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/dstockto/csv-chef/recipe"
+	"github.com/google/martian/log"
+	"github.com/spf13/cobra"
+)
+
+var (
+	lintRecipeFile string
+	lintInputFile  string
+)
+
+// lintCmd represents the lint command
+var lintCmd = &cobra.Command{
+	Use:   "lint -r /path/to/recipe [-i /path/to/input.csv]",
+	Short: "Validates a recipe without producing output",
+	Long: `Lint parses and validates a recipe file without transforming any data. It
+reports parse errors (such as unknown functions, unterminated literals or
+incorrect argument counts) and recipe validation errors (such as missing
+column definitions). If an input CSV is provided with -i, lint also checks
+that the recipe does not reference an input column number greater than the
+number of columns in the input file's header row.`,
+	Run: runLint,
+}
+
+func runLint(cmd *cobra.Command, args []string) {
+	if lintRecipeFile == "" {
+		log.Errorf("Please specify a recipe file path with -r or --recipe")
+		os.Exit(1)
+	}
+
+	recipeReader, err := os.Open(lintRecipeFile)
+	if err != nil {
+		log.Errorf("Unable to open recipe file: %v", err)
+		os.Exit(2)
+	}
+	defer func() { _ = recipeReader.Close() }()
+
+	transformer, err := recipe.Parse(recipeReader)
+	if err != nil {
+		log.Errorf("Error processing your recipe: %v", err)
+		os.Exit(3)
+	}
+
+	if err := transformer.ValidateRecipe(); err != nil {
+		log.Errorf("Recipe validation failed: %v", err)
+		os.Exit(4)
+	}
+
+	if lintInputFile != "" {
+		in, err := os.Open(lintInputFile)
+		if err != nil {
+			log.Errorf("Error opening input file: %v", err)
+			os.Exit(5)
+		}
+		defer func() { _ = in.Close() }()
+
+		header, err := csv.NewReader(in).Read()
+		if err == io.EOF {
+			log.Errorf("Input file %s is empty", lintInputFile)
+			os.Exit(6)
+		}
+		if err != nil {
+			log.Errorf("Error reading header row from input file: %v", err)
+			os.Exit(6)
+		}
+
+		headerWidth := len(header)
+		maxReferenced := transformer.MaxInputColumnReferenced()
+		if maxReferenced > headerWidth {
+			log.Errorf(
+				"Recipe references input column %d, but input file %s only has %d column(s) in its header row",
+				maxReferenced, lintInputFile, headerWidth,
+			)
+			os.Exit(7)
+		}
+	}
+
+	fmt.Println("Recipe OK")
+}
+
+func init() {
+	rootCmd.AddCommand(lintCmd)
+
+	lintCmd.Flags().StringVarP(&lintRecipeFile, "recipe", "r", "", "-r /path/to/recipe.txt")
+	lintCmd.Flags().StringVarP(&lintInputFile, "in", "i", "", "-i /path/to/input.csv")
+	_ = lintCmd.MarkFlagRequired("recipe")
+}

--- a/recipe/validate.go
+++ b/recipe/validate.go
@@ -1,0 +1,43 @@
+package recipe
+
+import "strconv"
+
+// MaxInputColumnReferenced scans every recipe (Variables, Columns and
+// Headers), every Operation in each recipe's Pipe and every Argument. For
+// arguments whose Type is Column, it parses the Value as an integer and
+// tracks the highest column number referenced. It returns 0 if no input
+// columns are referenced.
+func (t *Transformation) MaxInputColumnReferenced() int {
+	max := 0
+
+	check := func(recipes map[int]Recipe) {
+		for _, r := range recipes {
+			scanRecipe(r, &max)
+		}
+	}
+
+	for _, r := range t.Variables {
+		scanRecipe(r, &max)
+	}
+	check(t.Columns)
+	check(t.Headers)
+
+	return max
+}
+
+func scanRecipe(r Recipe, max *int) {
+	for _, op := range r.Pipe {
+		for _, arg := range op.Arguments {
+			if arg.Type != Column {
+				continue
+			}
+			col, err := strconv.Atoi(arg.Value)
+			if err != nil {
+				continue
+			}
+			if col > *max {
+				*max = col
+			}
+		}
+	}
+}

--- a/recipe/validate_test.go
+++ b/recipe/validate_test.go
@@ -1,0 +1,64 @@
+package recipe
+
+import "testing"
+
+func TestMaxInputColumnReferenced(t *testing.T) {
+	tests := []struct {
+		name           string
+		transformation *Transformation
+		want           int
+	}{
+		{
+			name:           "no column references returns 0",
+			transformation: NewTransformation(),
+			want:           0,
+		},
+		{
+			name: "literal only references no columns",
+			transformation: func() *Transformation {
+				tr := NewTransformation()
+				tr.AddOperationToColumn("1", Operation{
+					Name:      "value",
+					Arguments: []Argument{{Type: Literal, Value: "hello"}},
+				})
+				return tr
+			}(),
+			want: 0,
+		},
+		{
+			name: "tracks max column across recipes",
+			transformation: func() *Transformation {
+				tr := NewTransformation()
+				tr.AddOperationToColumn("1", Operation{
+					Name:      "value",
+					Arguments: []Argument{{Type: Column, Value: "3"}},
+				})
+				tr.AddOperationToColumn("2", Operation{
+					Name: "join",
+					Arguments: []Argument{
+						{Type: Column, Value: "7"},
+						{Type: Literal, Value: "x"},
+					},
+				})
+				tr.AddOperationToVariable("foo", Operation{
+					Name:      "value",
+					Arguments: []Argument{{Type: Column, Value: "5"}},
+				})
+				tr.AddOperationToHeader("1", Operation{
+					Name:      "value",
+					Arguments: []Argument{{Type: Column, Value: "2"}},
+				})
+				return tr
+			}(),
+			want: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.transformation.MaxInputColumnReferenced(); got != tt.want {
+				t.Errorf("MaxInputColumnReferenced() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a `lint` subcommand that parses and validates a recipe without transforming any data.

- Reports parse errors (unknown functions, unterminated literals, bad arg counts) and recipe validation errors (missing column defs), exiting non-zero on any problem.
- With `-i`, reads the input header row and warns/exits non-zero if the recipe references a column number wider than the header.
- Adds `Transformation.MaxInputColumnReferenced()` (with unit tests) to support the width check.
- Documents the command in the README.

Closes #57