### PR TITLE
Add string-manipulation recipe functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ I'll indicate that with empty parens. You can leave those off too. Functions are
 * replace(search, replace, ?) - If it finds the `search` string within the input, it will be replaced with the `replace` string. If it's not found, then it returns the original input unchanged.
 * power(num, power) - Returns `num` raised to the `power` parameter.  Both values must be numeric.  It will return a string representation of the number.
 * age(birthdate) - Returns the age, in years, of someone born on the birthdate provided
+* coalesce(a, b) - Returns `a` if it is not empty, otherwise returns `b`. Handy for falling back to a default value.
+* nth(delimiter, index, ?) - Splits the input on `delimiter` and returns the field at the 1-based `index`. If `index` is beyond the number of fields, an empty string is returned. The `delimiter` must not be empty and `index` must be an integer >= 1, or an error occurs.
+* padLeft(width, pad, ?) - Prepends copies of `pad` to the input until it is at least `width` characters (runes) long, then trims from the left so the result is exactly `width` characters. If the input is already at least `width` long, it is returned unchanged. `width` must be a non-negative integer and `pad` must be non-empty.
+* padRight(width, pad, ?) - Like padLeft, but appends `pad` on the right and trims any overflow from the right to exactly `width` characters (runes).
+* titleCase(?) - Title-cases each whitespace-separated word, making the first character uppercase and the rest lowercase. Words are separated by single spaces in the result.
+* regexReplace(pattern, replacement, ?) - Replaces all matches of the regular expression `pattern` in the input with `replacement` (capture groups like `$1` are supported). If `pattern` is not a valid regular expression, an error occurs.
+* substring(start, length, ?) - Returns up to `length` characters (runes) of the input starting at the 1-based position `start`. If `start` is beyond the input, an empty string is returned; the end is clamped to the input length. `start` must be an integer >= 1 and `length` an integer >= 0.
 
 Public Recipes
 ==

--- a/recipe/helper_functions.go
+++ b/recipe/helper_functions.go
@@ -348,6 +348,132 @@ func MassProcess(incoming []string, processor Processor) (out []string) {
 	return
 }
 
+func Coalesce(a string, b string) (string, error) {
+	if a != "" {
+		return a, nil
+	}
+	return b, nil
+}
+
+func Nth(delimiter string, index string, input string) (string, error) {
+	if delimiter == "" {
+		return "", errors.New("delimiter must not be empty")
+	}
+	idx, err := strconv.Atoi(index)
+	if err != nil {
+		return "", fmt.Errorf("index is not an integer: got '%s'", index)
+	}
+	if idx < 1 {
+		return "", fmt.Errorf("index must be >= 1: got '%d'", idx)
+	}
+
+	fields := strings.Split(input, delimiter)
+	if idx > len(fields) {
+		return "", nil
+	}
+	return fields[idx-1], nil
+}
+
+func PadLeft(width string, pad string, input string) (string, error) {
+	w, err := strconv.Atoi(width)
+	if err != nil {
+		return "", fmt.Errorf("width is not an integer: got '%s'", width)
+	}
+	if w < 0 {
+		return "", fmt.Errorf("width must be non-negative: got '%d'", w)
+	}
+	if pad == "" {
+		return "", errors.New("pad must not be empty")
+	}
+
+	r := []rune(input)
+	if len(r) >= w {
+		return input, nil
+	}
+
+	padRunes := []rune(pad)
+	var prefix []rune
+	for len(prefix)+len(r) < w {
+		prefix = append(prefix, padRunes...)
+	}
+	combined := append(prefix, r...)
+	// Trim from the left so the result is exactly w runes
+	return string(combined[len(combined)-w:]), nil
+}
+
+func PadRight(width string, pad string, input string) (string, error) {
+	w, err := strconv.Atoi(width)
+	if err != nil {
+		return "", fmt.Errorf("width is not an integer: got '%s'", width)
+	}
+	if w < 0 {
+		return "", fmt.Errorf("width must be non-negative: got '%d'", w)
+	}
+	if pad == "" {
+		return "", errors.New("pad must not be empty")
+	}
+
+	r := []rune(input)
+	if len(r) >= w {
+		return input, nil
+	}
+
+	padRunes := []rune(pad)
+	combined := append([]rune{}, r...)
+	for len(combined) < w {
+		combined = append(combined, padRunes...)
+	}
+	// Trim the overflow from the right so the result is exactly w runes
+	return string(combined[:w]), nil
+}
+
+func TitleCase(input string) (string, error) {
+	words := strings.Fields(input)
+	for i, word := range words {
+		r := []rune(word)
+		first := strings.ToUpper(string(r[0]))
+		rest := strings.ToLower(string(r[1:]))
+		words[i] = first + rest
+	}
+	return strings.Join(words, " "), nil
+}
+
+func RegexReplace(pattern string, replacement string, input string) (string, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", fmt.Errorf("invalid regular expression '%s': %v", pattern, err)
+	}
+	return re.ReplaceAllString(input, replacement), nil
+}
+
+func Substring(start string, length string, input string) (string, error) {
+	startNum, err := strconv.Atoi(start)
+	if err != nil {
+		return "", fmt.Errorf("start is not an integer: got '%s'", start)
+	}
+	if startNum < 1 {
+		return "", fmt.Errorf("start must be >= 1: got '%d'", startNum)
+	}
+	lengthNum, err := strconv.Atoi(length)
+	if err != nil {
+		return "", fmt.Errorf("length is not an integer: got '%s'", length)
+	}
+	if lengthNum < 0 {
+		return "", fmt.Errorf("length must be non-negative: got '%d'", lengthNum)
+	}
+
+	r := []rune(input)
+	startIdx := startNum - 1
+	if startIdx >= len(r) {
+		return "", nil
+	}
+	end := startIdx + lengthNum
+	if end > len(r) {
+		end = len(r)
+	}
+	return string(r[startIdx:end]), nil
+}
+
 // SanitizeField guards against CSV formula injection by prefixing a
 // single quote to any value that begins with a character a spreadsheet
 // may interpret as a formula.

--- a/recipe/helper_functions_test.go
+++ b/recipe/helper_functions_test.go
@@ -158,3 +158,212 @@ func TestSanitizeField(t *testing.T) {
 		})
 	}
 }
+
+func TestCoalesce(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want string
+	}{
+		{"first non-empty", "apple", "banana", "apple"},
+		{"first empty", "", "banana", "banana"},
+		{"both empty", "", "", ""},
+		{"first whitespace kept", " ", "banana", " "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Coalesce(tt.a, tt.b)
+			if err != nil {
+				t.Fatalf("Coalesce() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Coalesce(%q, %q) = %q, want %q", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNth(t *testing.T) {
+	tests := []struct {
+		name      string
+		delimiter string
+		index     string
+		input     string
+		want      string
+		wantErr   bool
+	}{
+		{name: "first field", delimiter: ",", index: "1", input: "a,b,c", want: "a"},
+		{name: "middle field", delimiter: ",", index: "2", input: "a,b,c", want: "b"},
+		{name: "last field", delimiter: ",", index: "3", input: "a,b,c", want: "c"},
+		{name: "beyond fields", delimiter: ",", index: "5", input: "a,b,c", want: ""},
+		{name: "multichar delimiter", delimiter: "::", index: "2", input: "a::b::c", want: "b"},
+		{name: "empty delimiter", delimiter: "", index: "1", input: "abc", wantErr: true},
+		{name: "non-int index", delimiter: ",", index: "x", input: "a,b", wantErr: true},
+		{name: "zero index", delimiter: ",", index: "0", input: "a,b", wantErr: true},
+		{name: "negative index", delimiter: ",", index: "-1", input: "a,b", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Nth(tt.delimiter, tt.index, tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Nth() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("Nth(%q, %q, %q) = %q, want %q", tt.delimiter, tt.index, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPadLeft(t *testing.T) {
+	tests := []struct {
+		name    string
+		width   string
+		pad     string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "pad with zeros", width: "5", pad: "0", input: "42", want: "00042"},
+		{name: "already long enough", width: "2", pad: "0", input: "42", want: "42"},
+		{name: "longer than width", width: "1", pad: "0", input: "42", want: "42"},
+		{name: "multichar pad trimmed left", width: "4", pad: "ab", input: "x", want: "babx"},
+		{name: "runes", width: "4", pad: "é", input: "ab", want: "ééab"},
+		{name: "zero width", width: "0", pad: "0", input: "ab", want: "ab"},
+		{name: "non-int width", width: "x", pad: "0", input: "ab", wantErr: true},
+		{name: "negative width", width: "-1", pad: "0", input: "ab", wantErr: true},
+		{name: "empty pad", width: "5", pad: "", input: "ab", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PadLeft(tt.width, tt.pad, tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("PadLeft() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("PadLeft(%q, %q, %q) = %q, want %q", tt.width, tt.pad, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	tests := []struct {
+		name    string
+		width   string
+		pad     string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "pad with spaces", width: "5", pad: " ", input: "ab", want: "ab   "},
+		{name: "already long enough", width: "2", pad: "0", input: "ab", want: "ab"},
+		{name: "longer than width", width: "1", pad: "0", input: "ab", want: "ab"},
+		{name: "multichar pad trimmed right", width: "5", pad: "ab", input: "x", want: "xabab"},
+		{name: "runes", width: "4", pad: "é", input: "ab", want: "abéé"},
+		{name: "zero width", width: "0", pad: "0", input: "ab", want: "ab"},
+		{name: "non-int width", width: "x", pad: "0", input: "ab", wantErr: true},
+		{name: "negative width", width: "-1", pad: "0", input: "ab", wantErr: true},
+		{name: "empty pad", width: "5", pad: "", input: "ab", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PadRight(tt.width, tt.pad, tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("PadRight() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("PadRight(%q, %q, %q) = %q, want %q", tt.width, tt.pad, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTitleCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "simple", input: "hello world", want: "Hello World"},
+		{name: "mixed case", input: "hELLO wORLD", want: "Hello World"},
+		{name: "all caps", input: "HELLO WORLD", want: "Hello World"},
+		{name: "collapses whitespace", input: "  hello   world  ", want: "Hello World"},
+		{name: "empty", input: "", want: ""},
+		{name: "single word", input: "banana", want: "Banana"},
+		{name: "unicode", input: "éric", want: "Éric"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TitleCase(tt.input)
+			if err != nil {
+				t.Fatalf("TitleCase() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("TitleCase(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegexReplace(t *testing.T) {
+	tests := []struct {
+		name        string
+		pattern     string
+		replacement string
+		input       string
+		want        string
+		wantErr     bool
+	}{
+		{name: "digits to hash", pattern: "[0-9]+", replacement: "#", input: "a1b22c", want: "a#b#c"},
+		{name: "capture group", pattern: "(\\w+)@(\\w+)", replacement: "$2.$1", input: "user@host", want: "host.user"},
+		{name: "no match", pattern: "z+", replacement: "x", input: "abc", want: "abc"},
+		{name: "invalid pattern", pattern: "(", replacement: "x", input: "abc", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RegexReplace(tt.pattern, tt.replacement, tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("RegexReplace() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("RegexReplace(%q, %q, %q) = %q, want %q", tt.pattern, tt.replacement, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubstring(t *testing.T) {
+	tests := []struct {
+		name    string
+		start   string
+		length  string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "middle", start: "2", length: "3", input: "abcdef", want: "bcd"},
+		{name: "from start", start: "1", length: "2", input: "abcdef", want: "ab"},
+		{name: "length beyond end clamps", start: "4", length: "10", input: "abcdef", want: "def"},
+		{name: "start beyond end", start: "10", length: "3", input: "abc", want: ""},
+		{name: "zero length", start: "1", length: "0", input: "abc", want: ""},
+		{name: "runes", start: "1", length: "2", input: "éîça", want: "éî"},
+		{name: "non-int start", start: "x", length: "2", input: "abc", wantErr: true},
+		{name: "start zero", start: "0", length: "2", input: "abc", wantErr: true},
+		{name: "negative start", start: "-1", length: "2", input: "abc", wantErr: true},
+		{name: "non-int length", start: "1", length: "x", input: "abc", wantErr: true},
+		{name: "negative length", start: "1", length: "-2", input: "abc", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Substring(tt.start, tt.length, tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Substring() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("Substring(%q, %q, %q) = %q, want %q", tt.start, tt.length, tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/recipe/parser.go
+++ b/recipe/parser.go
@@ -42,6 +42,13 @@ var allFuncs = map[string][]int{
 	"isfuture":     {3},
 	"power":        {2},
 	"age":          {1},
+	"coalesce":     {2},
+	"nth":          {3},
+	"padleft":      {3},
+	"padright":     {3},
+	"titlecase":    {1},
+	"regexreplace": {3},
+	"substring":    {3},
 }
 
 func Parse(source io.Reader) (*Transformation, error) {

--- a/recipe/recipe.go
+++ b/recipe/recipe.go
@@ -574,6 +574,76 @@ func (t *Transformation) processRecipe(recipeType string, variable Recipe, conte
 				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
 			}
 			value = result
+		case "coalesce":
+			args, err := processArgs(2, o.Arguments, context, placeholder)
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): error evaluating arg: %v", errorPrefix, opName, err)
+			}
+			result, err := Coalesce(args[0], args[1])
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
+			}
+			value = result
+		case "nth":
+			args, err := processArgs(3, o.Arguments, context, placeholder)
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): error evaluating arg: %v", errorPrefix, opName, err)
+			}
+			result, err := Nth(args[0], args[1], args[2])
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
+			}
+			value = result
+		case "padleft":
+			args, err := processArgs(3, o.Arguments, context, placeholder)
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): error evaluating arg: %v", errorPrefix, opName, err)
+			}
+			result, err := PadLeft(args[0], args[1], args[2])
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
+			}
+			value = result
+		case "padright":
+			args, err := processArgs(3, o.Arguments, context, placeholder)
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): error evaluating arg: %v", errorPrefix, opName, err)
+			}
+			result, err := PadRight(args[0], args[1], args[2])
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
+			}
+			value = result
+		case "titlecase":
+			args, err := processArgs(1, o.Arguments, context, placeholder)
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): error evaluating arg: %v", errorPrefix, opName, err)
+			}
+			result, err := TitleCase(args[0])
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
+			}
+			value = result
+		case "regexreplace":
+			args, err := processArgs(3, o.Arguments, context, placeholder)
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): error evaluating arg: %v", errorPrefix, opName, err)
+			}
+			result, err := RegexReplace(args[0], args[1], args[2])
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
+			}
+			value = result
+		case "substring":
+			args, err := processArgs(3, o.Arguments, context, placeholder)
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): error evaluating arg: %v", errorPrefix, opName, err)
+			}
+			result, err := Substring(args[0], args[1], args[2])
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
+			}
+			value = result
 		// TODO make function calling more smart, using the allFuncs thing
 		default:
 			return "", fmt.Errorf("%s error: processing variable, unimplemented operation %s", errorPrefix, o.Name)


### PR DESCRIPTION
Adds seven new string-manipulation recipe functions:

- `coalesce(a, b)` - returns `a` if non-empty, else `b`
- `nth(delimiter, index, ?)` - splits input on delimiter, returns 1-based index field ("" if beyond range)
- `padLeft(width, pad, ?)` - left-pads input to exactly `width` runes
- `padRight(width, pad, ?)` - right-pads input to exactly `width` runes
- `titleCase(?)` - title-cases each whitespace-separated word
- `regexReplace(pattern, replacement, ?)` - regex replace-all (errors on invalid pattern)
- `substring(start, length, ?)` - rune-aware 1-based substring

All functions are purely additive and backward-compatible; no existing recipe behavior changes. Includes table tests (success + error/edge cases) and README documentation.

Closes #55