### PR TITLE
Add configurable CSV delimiter to bake

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ If the bake function runs into a parse error when processing the incoming CSV fi
 
 You can stream data through `csv-chef` instead of using files. Pass `-i -` to read the input CSV from standard input, and pass `-o -` to write the output CSV to standard output. When writing to standard output, the "output file already exists" check is skipped and status messages are sent to standard error so they don't pollute the CSV stream. For example: `printf 'a\nb\n' | csv-chef bake -i - -o - -r recipe.txt -d`.
 
+By default `csv-chef` reads and writes comma-delimited files. You can change the field delimiter with `--delimiter`, which sets the delimiter for both input and output. To use different delimiters for each, use `--input-delimiter` and `--output-delimiter`, which override `--delimiter` for the input or output respectively. Each flag takes a single character; the literal two-character string `\t` is interpreted as a tab. For example, to round-trip a tab-separated file: `csv-chef bake -i in.tsv -o out.tsv -r recipe.txt --delimiter '\t'`.
+
 To guard against spreadsheet formula injection, you can provide the `-s` or `--sanitize` flag. When enabled, any output cell that begins with a character a spreadsheet might interpret as a formula (`=`, `+`, `-`, `@`, a tab, or a carriage return) is prefixed with a single quote. This is opt-in; by default output cells are written unchanged.
 
 Please see the recipes section for information about how to build recipes for the program.

--- a/cmd/bake.go
+++ b/cmd/bake.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"unicode/utf8"
 
 	"github.com/dstockto/csv-chef/recipe"
 	"github.com/google/martian/log"
@@ -34,14 +35,43 @@ import (
 )
 
 var (
-	transformLines int
-	disableHeader  bool
-	forceOverwrite bool
-	inputFile      string
-	outputFile     string
-	recipeFile     string
-	sanitize       bool
+	transformLines  int
+	disableHeader   bool
+	forceOverwrite  bool
+	inputFile       string
+	outputFile      string
+	recipeFile      string
+	sanitize        bool
+	delimiter       string
+	inputDelimiter  string
+	outputDelimiter string
 )
+
+// resolveDelimiter converts a delimiter flag string to a rune. The literal
+// two-character string `\t` is interpreted as a tab. Otherwise the string
+// must be exactly one rune. On invalid input the program exits non-zero.
+func resolveDelimiter(name, value string) rune {
+	if value == `\t` {
+		return '\t'
+	}
+	if utf8.RuneCountInString(value) != 1 {
+		log.Errorf("%s must be a single character (or the literal \\t for tab), got %q", name, value)
+		os.Exit(9)
+	}
+	return []rune(value)[0]
+}
+
+// effectiveDelimiter returns the specific override if set, else the shared
+// delimiter if set, else a comma.
+func effectiveDelimiter(name, specific, shared string) rune {
+	if specific != "" {
+		return resolveDelimiter(name, specific)
+	}
+	if shared != "" {
+		return resolveDelimiter("--delimiter", shared)
+	}
+	return ','
+}
 
 // bakeCmd represents the bake command
 var bakeCmd = &cobra.Command{
@@ -127,7 +157,15 @@ func runBake(cmd *cobra.Command, args []string) {
 		transformLines++
 	}
 
-	result, err := transformer.Execute(csv.NewReader(in), csv.NewWriter(out), !disableHeader, transformLines, parseErrIsError)
+	inComma := effectiveDelimiter("--input-delimiter", inputDelimiter, delimiter)
+	outComma := effectiveDelimiter("--output-delimiter", outputDelimiter, delimiter)
+
+	r := csv.NewReader(in)
+	r.Comma = inComma
+	w := csv.NewWriter(out)
+	w.Comma = outComma
+
+	result, err := transformer.Execute(r, w, !disableHeader, transformLines, parseErrIsError)
 	if err != nil {
 		log.Errorf("Error during baking: %v", err)
 		os.Exit(8)
@@ -153,6 +191,9 @@ func init() {
 	bakeCmd.Flags().StringVarP(&recipeFile, "recipe", "r", "", "-r /path/to/recipe.txt")
 	bakeCmd.Flags().BoolP("parseErrorIsError", "p", false, "-p")
 	bakeCmd.Flags().BoolVarP(&sanitize, "sanitize", "s", false, "--sanitize (prefix risky cells with a quote to prevent spreadsheet formula injection)")
+	bakeCmd.Flags().StringVar(&delimiter, "delimiter", "", "field delimiter for both input and output (default ,); use \\t for tab")
+	bakeCmd.Flags().StringVar(&inputDelimiter, "input-delimiter", "", "field delimiter for input only (overrides --delimiter)")
+	bakeCmd.Flags().StringVar(&outputDelimiter, "output-delimiter", "", "field delimiter for output only (overrides --delimiter)")
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// bakeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")


### PR DESCRIPTION
Adds `--delimiter`, `--input-delimiter`, and `--output-delimiter` flags to the `bake` command so files using a non-comma field separator can be processed. `--delimiter` sets both input and output; the per-direction flags override it. Each accepts a single character, and the literal `\t` is interpreted as a tab.

The default remains a comma, so existing recipes and files are unaffected.

Closes #52