### PR TITLE
Add trimZeros recipe function

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ I'll indicate that with empty parens. You can leave those off too. Functions are
 * multiply(?, ?) - returns the product of the two provided numerical values. If either are not numerical, an error will occur.
 * divide(?, ?) - provides the result of first value divided by the second. They should of course be numbers, and the second value should not be zero unless you want to cause damage to the space-time continuum.
 * numberFormat(digits, ?) - run this after add, subtract, multiply or divide to trim decimals. The `digits` parameter is how many digits after the decimal you want to keep.
+* trimZeros(?) - parses the input as a number and returns it with the fewest digits needed, dropping trailing zeros (and the decimal point if not needed). Run it after a math function to get clean output, e.g. `1 <- add(2, 3) -> trimZeros` yields `5` instead of `5.000000`, and `add(2, 3.5) -> trimZeros` yields `5.5`. A non-numeric input returns an error.
 * lineno() - this function returns the current line number
 * mod(x, y) - returns the remainder of dividing x by y. Both arguments need to be integers. If they are not, an error will happen. If y is zero, an error will be returned.
 * trim(?) - returns the argument with any leading or trailing white-space removed

--- a/recipe/helper_functions.go
+++ b/recipe/helper_functions.go
@@ -142,6 +142,14 @@ func Trim(input string) (string, error) {
 	return strings.TrimSpace(input), nil
 }
 
+func TrimZeros(input string) (string, error) {
+	f, err := strconv.ParseFloat(input, 64)
+	if err != nil {
+		return "", fmt.Errorf("trimZeros: input is not numeric: got '%s'", input)
+	}
+	return strconv.FormatFloat(f, 'f', -1, 64), nil
+}
+
 func Repeat(count string, input string) (string, error) {
 	num, err := strconv.Atoi(count)
 	if err != nil {

--- a/recipe/helper_functions_test.go
+++ b/recipe/helper_functions_test.go
@@ -367,3 +367,29 @@ func TestSubstring(t *testing.T) {
 		})
 	}
 }
+
+func TestTrimZeros(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "integer-valued float", input: "5.000000", want: "5"},
+		{name: "fractional", input: "5.500000", want: "5.5"},
+		{name: "plain decimal", input: "0.1", want: "0.1"},
+		{name: "plain integer", input: "42", want: "42"},
+		{name: "non-numeric", input: "abc", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TrimZeros(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("TrimZeros() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("TrimZeros(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/recipe/parser.go
+++ b/recipe/parser.go
@@ -27,6 +27,7 @@ var allFuncs = map[string][]int{
 	"onlydigits":   {1},
 	"mod":          {2},
 	"trim":         {1},
+	"trimzeros":    {1},
 	"firstchars":   {1},
 	"lastchars":    {1},
 	"repeat":       {2},

--- a/recipe/recipe.go
+++ b/recipe/recipe.go
@@ -443,6 +443,16 @@ func (t *Transformation) processRecipe(recipeType string, variable Recipe, conte
 			}
 			result, _ := Trim(args[0])
 			value = result
+		case "trimzeros":
+			args, err := processArgs(1, o.Arguments, context, placeholder)
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): error evaluating arg: %v", errorPrefix, opName, err)
+			}
+			result, err := TrimZeros(args[0])
+			if err != nil {
+				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
+			}
+			value = result
 		case "firstchars":
 			args, err := processArgs(2, o.Arguments, context, placeholder)
 			if err != nil {


### PR DESCRIPTION
Adds a new `trimZeros(?)` recipe function that parses its input as a number and re-formats it with the fewest digits needed, dropping trailing zeros (e.g. `5.000000` -> `5`, `5.500000` -> `5.5`). Recipe authors opt in by piping a math result through it, e.g. `1 <- add(2, 3) -> trimZeros`.

Purely additive: `Add`/`Subtract`/`Multiply`/`Divide`/`Power` keep their existing `%f` formatting, so existing recipes are unchanged.

Closes #54