### PR TITLE
Add --strict mode for lenient date functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ By default `csv-chef` reads and writes comma-delimited files. You can change the
 
 To guard against spreadsheet formula injection, you can provide the `-s` or `--sanitize` flag. When enabled, any output cell that begins with a character a spreadsheet might interpret as a formula (`=`, `+`, `-`, `@`, a tab, or a carriage return) is prefixed with a single quote. This is opt-in; by default output cells are written unchanged.
 
+The `--strict` flag makes the lenient date functions fail instead of silently passing input through. Normally `readDate` and `formatDate` return their input unchanged when it does not match the given format; with `--strict` they behave like `readDateF`/`formatDateF` and stop processing with an error. This is opt-in; by default these functions remain lenient. (The conditional functions such as `change` and `ifEmpty` are unaffected — passing a value through is their defined behavior, not a silent failure.)
+
 Please see the recipes section for information about how to build recipes for the program.
 
 Write

--- a/cmd/bake.go
+++ b/cmd/bake.go
@@ -45,6 +45,7 @@ var (
 	delimiter       string
 	inputDelimiter  string
 	outputDelimiter string
+	strict          bool
 )
 
 // resolveDelimiter converts a delimiter flag string to a rune. The literal
@@ -151,6 +152,7 @@ func runBake(cmd *cobra.Command, args []string) {
 	}
 
 	transformer.Sanitize = sanitize
+	transformer.Strict = strict
 
 	// Don't count the header
 	if transformLines > 0 && !disableHeader {
@@ -191,6 +193,7 @@ func init() {
 	bakeCmd.Flags().StringVarP(&recipeFile, "recipe", "r", "", "-r /path/to/recipe.txt")
 	bakeCmd.Flags().BoolP("parseErrorIsError", "p", false, "-p")
 	bakeCmd.Flags().BoolVarP(&sanitize, "sanitize", "s", false, "--sanitize (prefix risky cells with a quote to prevent spreadsheet formula injection)")
+	bakeCmd.Flags().BoolVar(&strict, "strict", false, "--strict (fail on unparseable dates in readDate/formatDate instead of passing them through)")
 	bakeCmd.Flags().StringVar(&delimiter, "delimiter", "", "field delimiter for both input and output (default ,); use \\t for tab")
 	bakeCmd.Flags().StringVar(&inputDelimiter, "input-delimiter", "", "field delimiter for input only (overrides --delimiter)")
 	bakeCmd.Flags().StringVar(&outputDelimiter, "output-delimiter", "", "field delimiter for output only (overrides --delimiter)")

--- a/recipe/recipe.go
+++ b/recipe/recipe.go
@@ -83,6 +83,9 @@ type Transformation struct {
 	Headers       map[int]Recipe
 	VariableOrder []string
 	Sanitize      bool
+	// Strict makes the lenient date-parsing functions (readDate, formatDate)
+	// fail on unparseable input instead of passing the value through.
+	Strict bool
 }
 
 type TransformationResult struct {
@@ -499,7 +502,12 @@ func (t *Transformation) processRecipe(recipeType string, variable Recipe, conte
 			if err != nil {
 				return "", fmt.Errorf("%s %s(): error evaluating arg: %v", errorPrefix, opName, err)
 			}
-			result, err := FormatDate(args[0], args[1])
+			// In strict mode, fail on unparseable dates instead of passing through.
+			format := FormatDate
+			if t.Strict {
+				format = FormatDateF
+			}
+			result, err := format(args[0], args[1])
 			if err != nil {
 				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
 			}
@@ -519,7 +527,12 @@ func (t *Transformation) processRecipe(recipeType string, variable Recipe, conte
 			if err != nil {
 				return "", fmt.Errorf("%s %s(): error evaluating arg: %v", errorPrefix, opName, err)
 			}
-			result, err := ReadDate(args[0], args[1])
+			// In strict mode, fail on unparseable dates instead of passing through.
+			read := ReadDate
+			if t.Strict {
+				read = ReadDateF
+			}
+			result, err := read(args[0], args[1])
 			if err != nil {
 				return "", fmt.Errorf("%s %s(): %v", errorPrefix, opName, err)
 			}

--- a/recipe/strict_test.go
+++ b/recipe/strict_test.go
@@ -1,0 +1,39 @@
+package recipe
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+	"testing"
+)
+
+// TestStrictMode_ReadDate verifies that readDate passes unparseable input
+// through by default but errors when the transformation is in strict mode.
+func TestStrictMode_ReadDate(t *testing.T) {
+	const recipeText = "1 <- readDate(\"2006-01-02\", 1)"
+	const input = "not-a-date\n"
+
+	// Default (lenient): the unparseable value is passed through unchanged.
+	lenient, err := Parse(strings.NewReader(recipeText))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := lenient.Execute(csv.NewReader(strings.NewReader(input)), csv.NewWriter(&buf), false, -1, false); err != nil {
+		t.Fatalf("lenient execute: unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "not-a-date" {
+		t.Errorf("lenient: got %q, want %q", got, "not-a-date")
+	}
+
+	// Strict: the unparseable value stops processing with an error.
+	strict, err := Parse(strings.NewReader(recipeText))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	strict.Strict = true
+	var strictBuf bytes.Buffer
+	if _, err := strict.Execute(csv.NewReader(strings.NewReader(input)), csv.NewWriter(&strictBuf), false, -1, false); err == nil {
+		t.Errorf("strict: expected an error for an unparseable date, got none")
+	}
+}


### PR DESCRIPTION
Adds a `--strict` flag to `bake` (and a `Strict` field on `Transformation`) that makes the lenient date functions fail instead of silently passing input through.

- `readDate` / `formatDate` normally return their input unchanged when it doesn't match the given format. With `--strict` they behave like `readDateF` / `formatDateF` and stop processing on an unparseable date.
- **Scope note:** the issue also named `change`/`changei`/`ifEmpty`, but those pass values through *by design* (a conditional result, not a silent failure), so there's nothing for strict mode to surface. They're intentionally excluded.
- Default behavior is unchanged (opt-in). Added a `recipe` test covering lenient vs strict, plus a README note.

`gofmt`, `vet`, `build`, `go test -race`, and `golangci-lint` all pass.

Closes #56